### PR TITLE
chore: disable homepage auto-open and pin settings

### DIFF
--- a/.obsidian/plugins/homepage/data.json
+++ b/.obsidian/plugins/homepage/data.json
@@ -4,7 +4,7 @@
     "Main Homepage": {
       "value": "Home",
       "kind": "File",
-      "openOnStartup": true,
+      "openOnStartup": false,
       "openMode": "Keep open notes",
       "manualOpenMode": "Keep open notes",
       "view": "Default view",
@@ -13,7 +13,7 @@
       "refreshDataview": false,
       "autoCreate": false,
       "autoScroll": false,
-      "pin": true,
+      "pin": false,
       "commands": [],
       "alwaysApply": false,
       "hideReleaseNotes": true


### PR DESCRIPTION
## Summary
- Disable homepage `openOnStartup` setting
- Disable homepage `pin` setting

🤖 Generated with [Claude Code](https://claude.com/claude-code)