### PR TITLE
Add Template filter to Files and Genre bases

### DIFF
--- a/Templates/Bases/Files.base
+++ b/Templates/Bases/Files.base
@@ -1,6 +1,7 @@
 filters:
   and:
     - file.folder = "Files"
+    - '!file.name.contains("Template")'
 properties:
   file.name:
     displayName: Name

--- a/Templates/Bases/Genre.base
+++ b/Templates/Bases/Genre.base
@@ -1,6 +1,7 @@
 filters:
   and:
     - list(genre).contains(this)
+    - '!file.name.contains("Template")'
 display:
   note.rating: Rating
   note.categories: Category


### PR DESCRIPTION
## Summary
Add `!file.name.contains("Template")` filter to Files.base and Genre.base to exclude template files from category views.

## Test plan
- [x] Files category view doesn't show template files
- [x] Genre category view doesn't show template files

🤖 Generated with [Claude Code](https://claude.com/claude-code)